### PR TITLE
Remove ViewHolder from being static

### DIFF
--- a/app/src/main/java/com/codepath/android/booksearch/adapters/BookAdapter.java
+++ b/app/src/main/java/com/codepath/android/booksearch/adapters/BookAdapter.java
@@ -21,7 +21,7 @@ public class BookAdapter extends RecyclerView.Adapter<BookAdapter.ViewHolder> {
     private Context mContext;
 
     // View lookup cache
-    public static class ViewHolder extends RecyclerView.ViewHolder {
+    public class ViewHolder extends RecyclerView.ViewHolder {
         public ImageView ivCover;
         public TextView tvTitle;
         public TextView tvAuthor;


### PR DESCRIPTION
If they want to implement just the simple OnClickListener on the ViewHolder, the ViewHolder can't be a static class.